### PR TITLE
Add ordinal filter

### DIFF
--- a/docs/filters/number.md
+++ b/docs/filters/number.md
@@ -22,6 +22,24 @@ true
 false
 ```
 
+## ordinal
+
+Convert a number into an ordinal numeral that follows [the GOV.UK style](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#ordinal-numbers).
+
+Input
+
+```njk
+{{ 4 | ordinal }}
+{{ 22 | ordinal }}
+```
+
+Output
+
+```html
+fourth
+22nd
+```
+
 ## sterling
 
 Convert a number into a string formatted as pound sterling. This can be useful for converting numbers into a human readable price.

--- a/lib/filters/number.js
+++ b/lib/filters/number.js
@@ -20,6 +20,53 @@ export function isNumber (value) {
 }
 
 /**
+ * Convert a number into an ordinal numeral.
+ *
+ * @see {@link https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#ordinal-numbers}
+ *
+ * @example
+ * ordinal(4) // fourth
+ * ordinal(22) // 22nd
+ *
+ * @param {number} number - Value to convert
+ * @return {string} Ordinal numeral or `number` with an ordinal suffix
+ */
+export function ordinal (number) {
+  number = _normalize(number, '')
+
+  // Spell out first to ninth
+  if (number < 10) {
+    const ordinals = new Map([
+      [1, 'first'],
+      [2, 'second'],
+      [3, 'third'],
+      [4, 'fourth'],
+      [5, 'fifth'],
+      [6, 'sixth'],
+      [7, 'seventh'],
+      [8, 'eighth'],
+      [9, 'ninth'],
+    ])
+
+    return ordinals.get(number)
+  }
+
+  // After that use 10th, 11th and so on
+  const rule = new Intl.PluralRules('en-GB', {
+    type: 'ordinal'
+  }).select(number)
+  const suffixes = new Map([
+    ['one', 'st'],
+    ['two', 'nd'],
+    ['few', 'rd'],
+    ['other', 'th']
+  ])
+  const suffix = suffixes.get(rule)
+
+  return `${number}${suffix}`
+}
+
+/**
  * Convert a number into a string formatted as pound sterling.
  *
  * @example
@@ -39,5 +86,6 @@ export function sterling (number) {
 
 export const numberFilters = {
   isNumber,
+  ordinal,
   sterling
 }


### PR DESCRIPTION
Convert a number into an ordinal numeral that follows [the GOV.UK style](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#ordinal-numbers).

Input

```njk
{{ 4 | ordinal }}
{{ 22 | ordinal }}
```

Output

```html
fourth
22nd
```