### PR TITLE
Add pluralise filter

### DIFF
--- a/docs/filters/string.md
+++ b/docs/filters/string.md
@@ -97,6 +97,30 @@ Output
 Department for Business, Energy & Industrial&amp;nbsp;Strategy
 ```
 
+## pluralise
+
+Get the plural form for an item for a given number of items.
+
+> This filter currently only works with English words.
+
+```njk
+{{ 1 | pluralise("mouse") }}
+{{ 2 | pluralise("house") }}
+{{ 2 | pluralise("house", { number: false }) }}
+{{ 2 | pluralise("mouse", { plural: "mice" }) }}
+{{ 2 | pluralise("mouse", { plural: "mice", number: false }) }}
+```
+
+Output
+
+```html
+1 mouse
+2 houses
+houses
+2 mice
+mice
+```
+
 ## slugify
 
 Convert a string to kebab-case. This can be useful to slugify titles for use in URLs or fragment identifiers.

--- a/lib/filters/string.js
+++ b/lib/filters/string.js
@@ -52,6 +52,31 @@ export function isString (value) {
 }
 
 /**
+ * Get the plural form for an item for a given number of items.
+ * Works for English words only.
+ *
+ * @see {@link http://blog.gnclmorais.com/simple-pluralise-in-javascript}
+ *
+ * @example
+ * pluralise(1, 'mouse') // 1 mouse
+ * pluralise(2, 'house') // 2 houses
+ * pluralise(2, 'house', { number: false }) // houses
+ * pluralise(2, 'mouse', { plural: 'mice' }) // 2 mice
+ * pluralise(2, 'mouse', { plural: 'mice', number: false }) // mice
+ *
+ * @param {number} count - Number of items
+ * @param {string} singular - Singular form
+ * @param {string} [plural={}] - Plural form
+ * @param {boolean} [number={}] - Output number alongside word
+ * @return {string} Plural form for `count`
+ */
+export function pluralise (count, singular, { plural, number } = {})  {
+  const message = count === 1 ? singular : (plural || `${singular}s`);
+
+  return number === false ? message : `${count} ${message}`;
+}
+
+/**
  * Insert a non-breaking space between the last two words of a string. This
  * prevents an orphaned word appearing by itself at the end of a paragraph.
  *
@@ -111,6 +136,7 @@ export const stringFilters = {
   govukMarkdown,
   isString,
   noOrphans,
+  pluralise,
   slugify,
   startsWith
 }


### PR DESCRIPTION
Get the plural form for an item for a given number of items.

```njk
{{ 1 | pluralise("mouse") }}
{{ 2 | pluralise("house") }}
{{ 2 | pluralise("house", { number: false }) }}
{{ 2 | pluralise("mouse", { plural: "mice" }) }}
{{ 2 | pluralise("mouse", { plural: "mice", number: false }) }}
```

Output

```html
1 mouse
2 houses
houses
10 mice
mice
```