### PR TITLE
Enhanced error page

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -21,7 +21,8 @@ Unbranded templates, jQuery and stylesheets for Internet Explorer 8 are also not
 
 ## Features
 
-* 404 and 500 error pages
+* Default 404 page
+* Error page that shows the cause of the error
 * [Feature flags](../using-data/feature-flags)
 * Session data output to the JavaScript console
 * Ability to use `async` functions for session data

--- a/lib/server.js
+++ b/lib/server.js
@@ -156,7 +156,7 @@ app.use((error, req, res, next) => {
   const status = error.status || 500
   res.status(status)
   res.render('500.njk', {
-    error: error.message,
+    error,
     status
   })
 })

--- a/lib/views/500.njk
+++ b/lib/views/500.njk
@@ -1,18 +1,22 @@
 {% extends "template.njk" %}
 
 {% set title = "Sorry, there is a problem with the prototype" %}
+{% set stackHtml %}
+<pre class="x-govuk-code x-govuk-code--block govuk-!-margin-0" tabindex="0"><code class="govuk-!-font-size-14">{{ error.stack }}</code></pre>
+{% endset %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">{{ title }}</h1>
-      <p class="govuk-body">The prototype encountered the following error:</p>
 
-      {{ govukInsetText({
-        html: "<code>" + error + "</code>"
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-2">{{ error.name }}</h2>
+      <p class="govuk-body"><code>{{ error.message | nl2br | nl2br | safe }}</code></p>
+      {{ govukDetails({
+        summaryHtml: "<code>Stack trace</code>",
+        html: stackHtml
       }) }}
 
-      <p class="govuk-body"><a href="/">Return to prototype homepage</a>.</p>
       <pre class="govuk-!-margin-top-8">Status code: {{ status }}</pre>
     </div>
   </div>


### PR DESCRIPTION
In addition to the error message, now also shows the name of the error and the stack trace:

<img width="760" alt="Screenshot 2022-06-09 at 21 03 42" src="https://user-images.githubusercontent.com/813383/172935242-86203408-8725-45e0-afae-1aa9f19a42e3.png">
