### PR TITLE
Allow google site verification pages to skip password protection

### DIFF
--- a/lib/middleware/authentication.js
+++ b/lib/middleware/authentication.js
@@ -4,7 +4,10 @@ import { encryptString } from '../utils.js'
 const publicPaths = [
   '/govuk/assets',
   '/prototype-password',
-  '/public'
+  '/public',
+  // A google site verification file such as
+  // googleabcde123456.html
+  '/google'
 ]
 
 /**
@@ -32,7 +35,7 @@ const redirectToPasswordPage = (req, res) => {
  */
 export function authentication (req, res, next) {
   // Don’t authenticate public paths or the password page
-  if (publicPaths.some(path => req.path.includes(path))) {
+  if (publicPaths.some(path => req.path.startsWith(path))) {
     return next()
   }
 


### PR DESCRIPTION
See https://support.google.com/webmasters/answer/9008080#meta_tag_verification&zippy=%2Chtml-tag%2Csites-that-use-a-website-hosting-platform%2Chtml-file-upload

An alternative would be a way of including the custom meta tag Google needs to find on the password protection – but that page extends template, which doesn't seem to be customisable from a prototype.