### PR TITLE
Allow rig views to extend a prototype layout

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -32,3 +32,4 @@ The following options can be set in your configuration file:
 | **useAutoStoreData** | boolean | Automatically store form data and send to all views. Default is `true`. |
 | **useCookieSessionStore** | boolean | Enable cookie-based session store (persists on restart). Please note 4KB cookie limit per domain, cookies too large will silently be ignored. Default is `false`. |
 | **useHttps** | boolean | Force HTTP to redirect to HTTPS on production. Default is `true`. |
+| **defaultRigLayout** | string | Use a layout from your prototype for the views provided by the rig. So, for example the ‘Clear session data’ and password pages can use a layout that matches the rest of your prototype. If no option is given rig pages will use the default `template.njk` layout. Example: `layouts/default.html`, if your prototype has a `default` layout in the `app/views/layouts` directory. Always include the file extension, `.html` or `.njk`. |

--- a/lib/views/404.njk
+++ b/lib/views/404.njk
@@ -1,4 +1,4 @@
-{% extends "template.njk" %}
+{% extends errorLayout or "template.njk" %}
 
 {% set title = "Page not found" %}
 

--- a/lib/views/404.njk
+++ b/lib/views/404.njk
@@ -1,4 +1,4 @@
-{% extends errorLayout or "template.njk" %}
+{% extends defaultRigLayout or "template.njk" %}
 
 {% set title = "Page not found" %}
 

--- a/lib/views/500.njk
+++ b/lib/views/500.njk
@@ -1,4 +1,4 @@
-{% extends errorLayout or "template.njk" %}
+{% extends "template.njk" %}
 
 {% set title = "Sorry, there is a problem with the prototype" %}
 {% set stackHtml %}

--- a/lib/views/500.njk
+++ b/lib/views/500.njk
@@ -1,4 +1,4 @@
-{% extends "template.njk" %}
+{% extends errorLayout or "template.njk" %}
 
 {% set title = "Sorry, there is a problem with the prototype" %}
 {% set stackHtml %}

--- a/lib/views/clear-session-data.njk
+++ b/lib/views/clear-session-data.njk
@@ -1,4 +1,4 @@
-{% extends defaultLayout or "template.njk" %}
+{% extends defaultRigLayout or "template.njk" %}
 
 {% set title = "Clear session data?" %}
 

--- a/lib/views/clear-session-data.njk
+++ b/lib/views/clear-session-data.njk
@@ -1,4 +1,4 @@
-{% extends "template.njk" %}
+{% extends defaultLayout or "template.njk" %}
 
 {% set title = "Clear session data?" %}
 

--- a/lib/views/feature-flags.njk
+++ b/lib/views/feature-flags.njk
@@ -1,4 +1,4 @@
-{% extends defaultLayout or "template.njk" %}
+{% extends defaultRigLayout or "template.njk" %}
 
 {% set title = "Feature flags" %}
 {% set preCode = "features: {

--- a/lib/views/feature-flags.njk
+++ b/lib/views/feature-flags.njk
@@ -1,4 +1,4 @@
-{% extends "template.njk" %}
+{% extends defaultLayout or "template.njk" %}
 
 {% set title = "Feature flags" %}
 {% set preCode = "features: {

--- a/lib/views/no-password-set.njk
+++ b/lib/views/no-password-set.njk
@@ -1,4 +1,4 @@
-{% extends "template.njk" %}
+{% extends defaultLayout or "template.njk" %}
 
 {% set title = "No password set" %}
 

--- a/lib/views/no-password-set.njk
+++ b/lib/views/no-password-set.njk
@@ -1,4 +1,4 @@
-{% extends defaultLayout or "template.njk" %}
+{% extends defaultRigLayout or "template.njk" %}
 
 {% set title = "No password set" %}
 

--- a/lib/views/password.njk
+++ b/lib/views/password.njk
@@ -1,4 +1,4 @@
-{% extends "template.njk" %}
+{% extends defaultLayout or "template.njk" %}
 
 {% set title = "This is a prototype used for research" %}
 

--- a/lib/views/password.njk
+++ b/lib/views/password.njk
@@ -1,4 +1,4 @@
-{% extends defaultLayout or "template.njk" %}
+{% extends defaultRigLayout or "template.njk" %}
 
 {% set title = "This is a prototype used for research" %}
 


### PR DESCRIPTION
Adds two choices:

1. defaultLayout
2. errorLayout

This is a non-breaking change as it will default to the existing template if no other one is given.
This will let the rig’s pages use things like a common footer, or other customisations.

Example usage:

```
"prototype": {
    "serviceName": "Find a lost teacher reference number (TRN)",
    "defaultLayout": "layouts/default.html"
}
```

Note the custom layout and different footer now used by the clear session page:

![Screenshot 2022-06-18 at 09 58 44](https://user-images.githubusercontent.com/319055/174430678-8d624e32-3789-4966-9b75-0079bb6cfcda.png)

