### PR TITLE
Add support for GOV.UK Frontend v4.2.0

### DIFF
--- a/lib/views/template.njk
+++ b/lib/views/template.njk
@@ -14,6 +14,7 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/skip-link/macro.njk" import govukSkipLink %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "express": "^4.17.3",
         "express-rate-limit": "^6.4.0",
         "express-session": "^1.13.0",
-        "govuk-frontend": "^4.1.0",
+        "govuk-frontend": "^4.2.0",
         "govuk-markdown": "^0.2.1",
         "govuk-prototype-components": "^0.3.0",
         "govuk-prototype-rig": "file:./",
@@ -4538,9 +4538,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.1.0.tgz",
-      "integrity": "sha512-xBUUarxinGWSccmXPmwa7ovg3xabEQ0+Dcv7pdq9X3F69892OFMqP2g8jvlDUrVsDVdasXLk4Jq4w8dPiaEVqQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.2.0.tgz",
+      "integrity": "sha512-IHbnz5DbnPjuCv4lQvtJGoCNAKAN6byKqmaej8hjd6Y/KTaAuw10npijeqfRJNO4WdDX9a34+n+SC/UmWdjfGQ==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -14588,9 +14588,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.1.0.tgz",
-      "integrity": "sha512-xBUUarxinGWSccmXPmwa7ovg3xabEQ0+Dcv7pdq9X3F69892OFMqP2g8jvlDUrVsDVdasXLk4Jq4w8dPiaEVqQ=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.2.0.tgz",
+      "integrity": "sha512-IHbnz5DbnPjuCv4lQvtJGoCNAKAN6byKqmaej8hjd6Y/KTaAuw10npijeqfRJNO4WdDX9a34+n+SC/UmWdjfGQ=="
     },
     "govuk-markdown": {
       "version": "0.2.3",
@@ -14631,7 +14631,7 @@
         "express-rate-limit": "^6.4.0",
         "express-session": "^1.13.0",
         "govuk-eleventy-plugin": "^2.4.0",
-        "govuk-frontend": "^4.1.0",
+        "govuk-frontend": "^4.2.0",
         "govuk-markdown": "^0.2.1",
         "govuk-prototype-components": "^0.3.0",
         "govuk-prototype-rig": "file:",
@@ -18055,9 +18055,9 @@
           }
         },
         "govuk-frontend": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.1.0.tgz",
-          "integrity": "sha512-xBUUarxinGWSccmXPmwa7ovg3xabEQ0+Dcv7pdq9X3F69892OFMqP2g8jvlDUrVsDVdasXLk4Jq4w8dPiaEVqQ=="
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.2.0.tgz",
+          "integrity": "sha512-IHbnz5DbnPjuCv4lQvtJGoCNAKAN6byKqmaej8hjd6Y/KTaAuw10npijeqfRJNO4WdDX9a34+n+SC/UmWdjfGQ=="
         },
         "govuk-markdown": {
           "version": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "express": "^4.17.3",
     "express-rate-limit": "^6.4.0",
     "express-session": "^1.13.0",
-    "govuk-frontend": "^4.1.0",
+    "govuk-frontend": "^4.2.0",
     "govuk-markdown": "^0.2.1",
     "govuk-prototype-components": "^0.3.0",
     "govuk-prototype-rig": "file:./",


### PR DESCRIPTION
Add support for GOV.UK Frontend v4.2.0. Requires increasing minimum version of the `govuk-frontend` dependency and including the `govukPagination` macro in the base template.