### PR TITLE
Ensure file paths used for dynamic imports. fixes #161

### DIFF
--- a/lib/middleware/auto-store-data.js
+++ b/lib/middleware/auto-store-data.js
@@ -1,3 +1,5 @@
+import { pathToFileURL } from 'node:url'
+
 /**
  * @access private
  * @param {Object} input - Original data
@@ -53,12 +55,14 @@ const _storeData = (input, data) => {
  * @returns {Function} Express middleware
  */
 export async function autoStoreData (req, res, next) {
-  // Get session default data from file
   let sessionDataDefaults = {}
-  const sessionDataDefaultsFile = `${process.cwd()}/app/data.js`
+
+  // Get session default data from file
+  let sessionDataDefaultsPath = process.cwd() + '/app/data.js'
+  sessionDataDefaultsPath = pathToFileURL(sessionDataDefaultsPath).href
 
   try {
-    sessionDataDefaults = await import(sessionDataDefaultsFile)
+    sessionDataDefaults = await import(sessionDataDefaultsPath)
 
     // Session data can be an (async) function object
     if (typeof sessionDataDefaults.default === 'function') {

--- a/lib/nunjucks.js
+++ b/lib/nunjucks.js
@@ -1,10 +1,12 @@
 import fs from 'node:fs'
+import { pathToFileURL } from 'node:url'
 import nunjucks from 'nunjucks'
 import { filters } from './filters/index.js'
 import { globals } from './globals/index.js'
 
 /**
  * Merge provided filters with any added by the prototype author.
+ * App filters can access package filters using `env.getFilter()`.
  *
  * @access private
  * @param {Object} nunjucksAppEnv - Nunjucks environment
@@ -14,12 +16,11 @@ async function _addFilters (nunjucksAppEnv) {
     nunjucksAppEnv.addFilter(filter, filters[filter])
   }
 
-  // Add any app filters to Nunjucks environment
-  // App filters can access package filters using env.getFilter()
-  const appFiltersPath = `${process.cwd()}/app/filters.js`
-
   let appFilters
+  let appFiltersPath = process.cwd() + '/app/filters.js'
+
   if (fs.existsSync(appFiltersPath)) {
+    appFiltersPath = pathToFileURL(appFiltersPath).href
     appFilters = await import(appFiltersPath)
     appFilters = appFilters.default(nunjucksAppEnv)
 
@@ -40,10 +41,11 @@ async function _addGlobals (nunjucksAppEnv) {
     nunjucksAppEnv.addGlobal(global, globals[global])
   }
 
-  const appGlobalsPath = `${process.cwd()}/app/globals.js`
-
   let appGlobals
+  let appGlobalsPath = process.cwd() + '/app/globals.js'
+
   if (fs.existsSync(appGlobalsPath)) {
+    appGlobalsPath = pathToFileURL(appGlobalsPath).href
     appGlobals = await import(appGlobalsPath)
     appGlobals = appGlobals.default()
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import { pathToFileURL } from 'node:url'
 import cookieParser from 'cookie-parser'
 import express from 'express'
 import rateLimit from 'express-rate-limit'
@@ -121,8 +122,9 @@ app.use(robotsRoutes(router))
 app.use(featureFlagRoutes(router))
 
 // Load routes
-const appRoutesPath = `${process.cwd()}/app/routes.js`
+let appRoutesPath = process.cwd() + 'app/routes.js'
 if (fs.existsSync(appRoutesPath)) {
+  appRoutesPath = pathToFileURL(appRoutesPath).href
   const appRoutes = await import(appRoutesPath)
   app.use('/', appRoutes.default)
 }


### PR DESCRIPTION
Going by similar issues as #161 reported on other projects, it appears that [`pathToFileURL`](https://nodejs.org/api/url.html#urlpathtofileurlpath) should be used when passing paths to `import()`. This ensures the `file:` protocol is used, and not local file paths such as those used by Windows that may begin with something like `c:`.

🤞 this fixes this compatibility issue on Windows.