### PR TITLE
Use new decorated components module

### DIFF
--- a/lib/globals/index.js
+++ b/lib/globals/index.js
@@ -1,4 +1,4 @@
-import { decorate } from 'govuk-prototype-components/decorate'
+import { decorate } from 'govuk-decorated-components'
 import { checked } from './checked.js'
 
 export const globals = {

--- a/lib/nunjucks.js
+++ b/lib/nunjucks.js
@@ -58,6 +58,7 @@ async function _addGlobals (nunjucksAppEnv) {
 export const getNunjucksEnv = (app, env) => {
   const appViews = [
     './node_modules/govuk-frontend',
+    './node_modules/govuk-decorated-components',
     './node_modules/govuk-prototype-components',
     './node_modules/govuk-prototype-rig/lib/views',
     './app',

--- a/lib/views/template.njk
+++ b/lib/views/template.njk
@@ -22,15 +22,15 @@
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-{% from "x-govuk/components/decorated/button/macro.njk" import govukButton with context %}
-{% from "x-govuk/components/decorated/character-count/macro.njk" import govukCharacterCount with context %}
-{% from "x-govuk/components/decorated/checkboxes/macro.njk" import govukCheckboxes with context %}
-{% from "x-govuk/components/decorated/date-input/macro.njk" import govukDateInput with context %}
-{% from "x-govuk/components/decorated/file-upload/macro.njk" import govukFileUpload with context %}
-{% from "x-govuk/components/decorated/input/macro.njk" import govukInput with context %}
-{% from "x-govuk/components/decorated/radios/macro.njk" import govukRadios with context %}
-{% from "x-govuk/components/decorated/select/macro.njk" import govukSelect with context %}
-{% from "x-govuk/components/decorated/textarea/macro.njk" import govukTextarea with context %}
+{% from "x-govuk/decorated/button/macro.njk" import govukButton with context %}
+{% from "x-govuk/decorated/character-count/macro.njk" import govukCharacterCount with context %}
+{% from "x-govuk/decorated/checkboxes/macro.njk" import govukCheckboxes with context %}
+{% from "x-govuk/decorated/date-input/macro.njk" import govukDateInput with context %}
+{% from "x-govuk/decorated/file-upload/macro.njk" import govukFileUpload with context %}
+{% from "x-govuk/decorated/input/macro.njk" import govukInput with context %}
+{% from "x-govuk/decorated/radios/macro.njk" import govukRadios with context %}
+{% from "x-govuk/decorated/select/macro.njk" import govukSelect with context %}
+{% from "x-govuk/decorated/textarea/macro.njk" import govukTextarea with context %}
 
 {% from "x-govuk/components/autocomplete/macro.njk" import xGovukAutocomplete with context %}
 {% from "x-govuk/components/masthead/macro.njk" import xGovukMasthead %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "express": "^4.17.3",
         "express-rate-limit": "^6.4.0",
         "express-session": "^1.13.0",
+        "govuk-decorated-components": "^1.0.0",
         "govuk-frontend": "^4.3.0",
         "govuk-markdown": "^0.3.0",
         "govuk-prototype-components": "^0.6.0",
@@ -4100,6 +4101,17 @@
       "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
       "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
       "dev": true
+    },
+    "node_modules/govuk-decorated-components": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-decorated-components/-/govuk-decorated-components-1.0.0.tgz",
+      "integrity": "sha512-echWrrfYUiEKTwMbFfHRSUYCj3dBSrmU+jg/X7cIsr8N6qXOJYearNaOTteGVo415uWChxx6uScgh1plqugcqg==",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/govuk-eleventy-plugin": {
       "version": "3.0.0",
@@ -13205,6 +13217,14 @@
       "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
       "dev": true
     },
+    "govuk-decorated-components": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-decorated-components/-/govuk-decorated-components-1.0.0.tgz",
+      "integrity": "sha512-echWrrfYUiEKTwMbFfHRSUYCj3dBSrmU+jg/X7cIsr8N6qXOJYearNaOTteGVo415uWChxx6uScgh1plqugcqg==",
+      "requires": {
+        "lodash": "^4.17.21"
+      }
+    },
     "govuk-eleventy-plugin": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/govuk-eleventy-plugin/-/govuk-eleventy-plugin-3.0.0.tgz",
@@ -13330,6 +13350,7 @@
         "express": "^4.17.3",
         "express-rate-limit": "^6.4.0",
         "express-session": "^1.13.0",
+        "govuk-decorated-components": "*",
         "govuk-eleventy-plugin": "^3.0.0",
         "govuk-frontend": "^4.3.0",
         "govuk-markdown": "^0.3.0",
@@ -16403,6 +16424,14 @@
           "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
           "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
           "dev": true
+        },
+        "govuk-decorated-components": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/govuk-decorated-components/-/govuk-decorated-components-1.0.0.tgz",
+          "integrity": "sha512-echWrrfYUiEKTwMbFfHRSUYCj3dBSrmU+jg/X7cIsr8N6qXOJYearNaOTteGVo415uWChxx6uScgh1plqugcqg==",
+          "requires": {
+            "lodash": "^4.17.21"
+          }
         },
         "govuk-eleventy-plugin": {
           "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "express": "^4.17.3",
     "express-rate-limit": "^6.4.0",
     "express-session": "^1.13.0",
+    "govuk-decorated-components": "^1.0.0",
     "govuk-frontend": "^4.3.0",
     "govuk-markdown": "^0.3.0",
     "govuk-prototype-components": "^0.6.0",


### PR DESCRIPTION
Use the new [`govuk-decorated-components`](https://github.com/x-govuk/govuk-decorated-components) package.

@fofr If you approve this PR, I’ll release the above as a package on npm and update this PR to point to the published package.