### PR TITLE
Specify a max node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     ]
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=16.0.0 >17"
   },
   "type": "module",
   "stylelint": {


### PR DESCRIPTION
Without this, Heroku installs the latest possible Node, which is currently 19. This fails to build at the moment.

Fixes #183.